### PR TITLE
Make browserify a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
   },
   "dependencies": {
     "date-fns": "^1.24.0",
+    "ember-browserify": "^1.1.13",
     "ember-cli-babel": "^5.1.7"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^2.4.1",
-    "ember-browserify": "^1.1.13",
     "ember-cli": "2.10.0",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-dependency-checker": "^1.3.0",


### PR DESCRIPTION
`ember install ember-date-fns` should just work afterwards.